### PR TITLE
Add method for getting the navigation bar height

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Returns top offset of the status bar
 
 **Returns:** <code>Promise&lt;<a href="#topreturn">TopReturn</a>&gt;</code>
 
+--------------------
+
+
 ### bottom()
 
 ```typescript
@@ -72,6 +75,7 @@ Returns bottom offset of the navigation bar
 | Prop        | Type                |
 | ----------- | ------------------- |
 | **`value`** | <code>number</code> |
+
 
 #### BottomReturn
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This plugin is required only on Android when using `StatusBar.setOverlaysWebView
 import { AndroidInsets } from 'capacitor-plugin-android-insets'
 
 const { value } = await AndroidInsets.top();
+const { value } = await AndroidInsets.bottom();
 ```
 
 ## API
@@ -32,6 +33,7 @@ const { value } = await AndroidInsets.top();
 <docgen-index>
 
 * [`top()`](#top)
+* [`bottom()`](#bottom)
 * [Interfaces](#interfaces)
 
 </docgen-index>
@@ -49,6 +51,16 @@ Returns top offset of the status bar
 
 **Returns:** <code>Promise&lt;<a href="#topreturn">TopReturn</a>&gt;</code>
 
+### bottom()
+
+```typescript
+bottom() => Promise<BottomReturn>
+```
+
+Returns bottom offset of the navigation bar
+
+**Returns:** <code>Promise&lt;<a href="#bottomreturn">BottomReturn</a>&gt;</code>
+
 --------------------
 
 
@@ -56,6 +68,12 @@ Returns top offset of the status bar
 
 
 #### TopReturn
+
+| Prop        | Type                |
+| ----------- | ------------------- |
+| **`value`** | <code>number</code> |
+
+#### BottomReturn
 
 | Prop        | Type                |
 | ----------- | ------------------- |

--- a/android/src/main/java/com/owlsdepartment/plugin/android/insets/AndroidInsets.java
+++ b/android/src/main/java/com/owlsdepartment/plugin/android/insets/AndroidInsets.java
@@ -12,14 +12,28 @@ public class AndroidInsets {
     }
 
     public float getTop() {
-        DisplayMetrics metrics = this.activity.getResources().getDisplayMetrics();
-        int resourceId = this.activity.getResources().getIdentifier("status_bar_height", "dimen", "android");
+        Resources resources = this.activity.getResources();
+        DisplayMetrics metrics = resources.getDisplayMetrics();
+        int resourceId = resources.getIdentifier("status_bar_height", "dimen", "android");
         float titleBarHeight = 0;
 
         if (resourceId > 0) {
-            titleBarHeight = this.activity.getResources().getDimensionPixelSize(resourceId);
+            titleBarHeight = resources.getDimensionPixelSize(resourceId);
         }
 
         return titleBarHeight / metrics.density;
+    }
+
+    public float getBottom() {
+        Resources resources = this.activity.getResources();
+        DisplayMetrics metrics = resources.getDisplayMetrics();
+        int resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
+        float navigationBarHeight = 0;
+
+        if (resourceId > 0) {
+            navigationBarHeight = resources.getDimensionPixelSize(resourceId);
+        }
+
+        return navigationBarHeight / metrics.density;
     }
 }

--- a/android/src/main/java/com/owlsdepartment/plugin/android/insets/AndroidInsets.java
+++ b/android/src/main/java/com/owlsdepartment/plugin/android/insets/AndroidInsets.java
@@ -1,5 +1,6 @@
 package com.owlsdepartment.plugin.android.insets;
 
+import android.content.res.Resources;
 import android.util.DisplayMetrics;
 import androidx.appcompat.app.AppCompatActivity;
 

--- a/android/src/main/java/com/owlsdepartment/plugin/android/insets/AndroidInsetsPlugin.java
+++ b/android/src/main/java/com/owlsdepartment/plugin/android/insets/AndroidInsetsPlugin.java
@@ -25,4 +25,13 @@ public class AndroidInsetsPlugin extends Plugin {
         ret.put("value", statusBarHeight);
         call.resolve(ret);
     }
+
+    @PluginMethod
+    public void bottom(PluginCall call) {
+        float navigationBarHeight = implementation.getBottom();
+        JSObject ret = new JSObject();
+
+        ret.put("value", navigationBarHeight);
+        call.resolve(ret);
+    }
 }

--- a/ios/Plugin/AndroidInsets.swift
+++ b/ios/Plugin/AndroidInsets.swift
@@ -4,4 +4,8 @@ import Foundation
     @objc public func top() -> Float {
         return 0
     }
+
+    @objc public func bottom() -> Float {
+        return 0
+    }
 }

--- a/ios/Plugin/AndroidInsetsPlugin.swift
+++ b/ios/Plugin/AndroidInsetsPlugin.swift
@@ -14,4 +14,10 @@ public class AndroidInsetsPlugin: CAPPlugin {
             "value": implementation.top()
         ])
     }
+
+    @objc func bottom(_ call: CAPPluginCall) {
+        call.resolve([
+            "value": implementation.bottom()
+        ])
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-plugin-android-insets",
-  "version": "1.0.0",
+  "version": "0.0.2",
   "description": "Capacitor plugin for retrieving proper top offset of Android status bar",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
@@ -41,7 +41,8 @@
     "build": "npm run clean && npm run docgen && tsc && rollup -c rollup.config.js",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "@capacitor/android": "^5.0.0",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -3,8 +3,17 @@ export interface AndroidInsetsPlugin {
    * Returns top offset of the status bar
    */
   top(): Promise<TopReturn>;
+
+  /**
+   * Returns bottom offset of the navigation bar
+   */
+  bottom(): Promise<BottomReturn>;
 }
 
 export interface TopReturn {
+  value: number;
+}
+
+export interface BottomReturn {
   value: number;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,9 +1,13 @@
 import { WebPlugin } from '@capacitor/core';
 
-import type { AndroidInsetsPlugin, TopReturn } from './definitions';
+import type { AndroidInsetsPlugin, BottomReturn, TopReturn } from './definitions';
 
 export class AndroidInsetsWeb extends WebPlugin implements AndroidInsetsPlugin {
   async top(): Promise<TopReturn> {
+    return { value: 0 };
+  }
+
+  async bottom(): Promise<BottomReturn> {
     return { value: 0 };
   }
 }


### PR DESCRIPTION
I added another method named `getBottom()` to get the height of the navigation bar.

This is useful when using a plugin like [@hugotomazi/capacitor-navigation-bar](https://github.com/hugotomazi/navigation-bar) to set the navigation bar to transparent (with `NavigationBar.setTransparency({ isTransparent: true });`).
In this case, the missing bottom inset makes the content of the app appear behind the navigation bar.

@owlsdepartment @przyb if you could publish a new version to npm it would be greatly appreciated.